### PR TITLE
fix(core/genesis): set WithdrawalsHash on Cancun-active genesis headers (fresh L1 produces no blocks)

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -471,6 +471,21 @@ func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) *types.Blo
 				withdrawals = make([]*types.Withdrawal, 0)
 			}
 			if conf.IsCancun(num, g.Timestamp) {
+				// Cancun implies Shanghai: a Cancun header MUST carry a
+				// WithdrawalsHash because the RLP codec reads it positionally
+				// before the Cancun fields below. The `num.Sign() != 0` guard
+				// above omits it at genesis, yielding an undecodable header
+				// ("rlp: input string too short for common.Hash, decoding into
+				// ...WithdrawalsHash") — which makes NewHeaderChain fabricate a
+				// fake genesis header and the chain produce zero blocks. Set it
+				// here so the genesis header round-trips. Chains that must keep a
+				// pre-withdrawals genesis hash opt out entirely via SkipPostMergeFields.
+				if head.WithdrawalsHash == nil {
+					head.WithdrawalsHash = &types.EmptyWithdrawalsHash
+					if withdrawals == nil {
+						withdrawals = make([]*types.Withdrawal, 0)
+					}
+				}
 				// EIP-4788: The parentBeaconBlockRoot of the genesis block is always
 				// the zero hash. This is because the genesis block does not have a parent
 				// by definition.
@@ -563,10 +578,6 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 
 	// Write chain config
 	customrawdb.WriteChainConfig(db, hash, config)
-
-	// Verify the block can be read back - remove debug code later
-	// canonHash := rawdb.ReadCanonicalHash(db, 0)
-	// log.Info("After write check", "canonical_hash", canonHash, "block_hash", block.Hash(), "match", canonHash == block.Hash())
 
 	return block, nil
 }


### PR DESCRIPTION
## Symptom
A fresh L1 with Cancun active at genesis (CancunTime=0) produces **zero blocks**. Every tx is built into a block that fails verification; `NewHeaderChain` logs *'Critical: Genesis header not readable despite canonical hash'* and fabricates a fake genesis header.

## Root cause
`toBlock` populates the Cancun fields (ParentBeaconRoot/ExcessBlobGas/BlobGasUsed) at genesis but leaves `WithdrawalsHash` nil — the WithdrawalsHash assignment is guarded by `num.Sign() != 0` (skipped at block 0). RLP encodes post-merge fields positionally, so a nil WithdrawalsHash *followed by present Cancun fields* yields a header `rawdb.ReadHeader` cannot decode:
```
rlp: input string too short for common.Hash, decoding into (types.hdr20eth).WithdrawalsHash
```
The fake header `NewHeaderChain` then creates has the wrong state root, so block-building fails and the deployer reads balance 0 at the genesis state (masked by the pathdb snapshot at `latest`, exposed under hashdb).

## Fix
Cancun implies Shanghai → a Cancun header MUST carry `WithdrawalsHash`. Set it to `EmptyWithdrawalsHash` whenever Cancun is active and it's nil. Chains preserving a pre-withdrawals genesis hash already opt out via `SkipPostMergeFields` (short-circuits the whole post-merge block), so they're unaffected.

## Verified
lqd devnet (chainId 8675312): genesis header round-trips (`ReadHeader` non-nil), `eth_getBalance(deployer,'0x0')`=funded, self-transfer **mines block 1**. Diagnosed via instrumented genesis-commit (`rawHeaderRLPlen` 572→604 with the WithdrawalsHash present).